### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/spf/core/emails.py
+++ b/spf/core/emails.py
@@ -68,7 +68,7 @@ def validate_email_address(email_to, email_from, debug=False):
     domain = email_to.split('@')[1]
     remote_server = get_mx_record(domain)
 
-    if (remote_server == None):
+    if (remote_server is None):
         print "No valid email server could be found for [%s]!" % (email_to)
         return False
 
@@ -112,7 +112,7 @@ def send_email_direct(email_to, email_from, display_name, subject, body, attach_
     # find the appropiate mail server
     domain = email_to.split('@')[1]
     remote_server = get_mx_record(domain)
-    if (remote_server == None):
+    if (remote_server is None):
         print "No valid email server could be found for [%s]!" % (email_to)
         return
 

--- a/spf/core/framework.py
+++ b/spf/core/framework.py
@@ -369,7 +369,7 @@ class Framework(object):
         if (self.config['verbose'] > 1):
             self.display.enableDebug()
 
-        if (self.config["ip"] == "0.0.0.0") or (self.config["ip"] == None):
+        if (self.config["ip"] == "0.0.0.0") or (self.config["ip"] is None):
             self.config["ip"]=Utils.getIP()
 
         # set logging path

--- a/spf/core/mydb.py
+++ b/spf/core/mydb.py
@@ -16,7 +16,7 @@ class MyDB():
             self.initDB()
 
     def getCursor(self):
-        if (self.conn == None):
+        if (self.conn is None):
             #print self.sqlite_file
             try:
                 self.conn = sqlite3.connect(self.sqlite_file)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:tatanus:SPF?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:tatanus:SPF?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)